### PR TITLE
🗃 Add prisma seed script for csv

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,4 @@ node_modules/
 .env
 variables.env
 resources/
+*.csv

--- a/backend/datamodel.graphql
+++ b/backend/datamodel.graphql
@@ -12,8 +12,8 @@ type User {
 
 type Post {
   id: ID! @unique
-  langauge: Language!
-  library: [Library!]!
+  language: Language!
+  tags: [String!]!
   contentType: ContentType!
   difficulty: Difficulty!
   title: String!
@@ -40,14 +40,14 @@ type Review {
 enum Language {
   JAVASCRIPT
   PYTHON
-  CPLUSPLUS
-}
-
-enum Library {
-  NATIVE
-  REACT
-  GRAPHQL
-  NEXT
+  CSHARP
+  CSS
+  CLI
+  LINUX
+  AWS
+  GIT
+  JAVA
+  MARKDOWN
 }
 
 # general categories of content
@@ -61,7 +61,7 @@ enum ContentType {
 # difficulty level of content
 enum Difficulty {
   EASY
-  INTERMEDIATE
+  MID
   HARD
   EXPERT
 }

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,5 +1,5 @@
 {
-  "name": "backend",
+  "name": "the_source_backend",
   "version": "1.0.0",
   "lockfileVersion": 1,
   "requires": true,
@@ -341,6 +341,15 @@
         "url": "0.10.3",
         "uuid": "3.1.0",
         "xml2js": "0.4.19"
+      }
+    },
+    "axios": {
+      "version": "0.18.0",
+      "resolved": "http://registry.npmjs.org/axios/-/axios-0.18.0.tgz",
+      "integrity": "sha1-MtU+SFHv3AoRmTts0AB4nXDAUQI=",
+      "requires": {
+        "follow-redirects": "^1.3.0",
+        "is-buffer": "^1.1.5"
       }
     },
     "backo2": {
@@ -787,6 +796,11 @@
       "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-1.0.0.tgz",
       "integrity": "sha1-ojD2T1aDEOFJgAmUB5DsmVRbyn4="
     },
+    "csv-parse": {
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/csv-parse/-/csv-parse-4.0.1.tgz",
+      "integrity": "sha512-ehkwejEj05wwO7Q9JD+YSI6dNMIauHIroNU1RALrmRrqPoZIwRnfBtgq5GkU6i2RxZOJqjo3dtI1NrVSXvaimA=="
+    },
     "dataloader": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/dataloader/-/dataloader-1.4.0.tgz",
@@ -1208,6 +1222,24 @@
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/statuses/-/statuses-1.4.0.tgz",
           "integrity": "sha512-zhSCtt8v2NDrRlPQpCNtw/heZLtfUDqxBM1udqikb/Hbk52LK4nQSwr10u77iopCW5LsyHpuXS0GnEc48mLeew=="
+        }
+      }
+    },
+    "follow-redirects": {
+      "version": "1.5.10",
+      "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+      "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+      "requires": {
+        "debug": "=3.1.0"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
         }
       }
     },

--- a/backend/package.json
+++ b/backend/package.json
@@ -4,6 +4,7 @@
   "description": "prisma backend for the source",
   "main": "src/index.js",
   "scripts": {
+    "seed": "prisma seed --reset",
     "deploy": "prisma deploy -e .env",
     "dev": "nodemon -e js,graphql -x node --inspect src/index.js"
   },
@@ -11,6 +12,8 @@
   "author": "chingu-7-bears-2",
   "license": "ISC",
   "dependencies": {
+    "axios": "^0.18.0",
+    "csv-parse": "^4.0.1",
     "dotenv": "^6.1.0",
     "graphql-yoga": "^1.16.7",
     "nodemon": "^1.18.7",

--- a/backend/prisma.yml
+++ b/backend/prisma.yml
@@ -1,5 +1,9 @@
 endpoint: ${env:PRISMA_ENDPOINT}
 datamodel: datamodel.graphql
+secret: ${env:PRISMA_SERVICE_SECRET}
+
+seed:
+  run: node seed/index.js
 
 generate:
   - generator: javascript-client

--- a/backend/seed/index.js
+++ b/backend/seed/index.js
@@ -1,0 +1,136 @@
+require('dotenv').config()
+const parse = require('csv-parse')
+const axios = require('axios')
+const fs = require('fs')
+const path = require('path')
+const { promisify } = require('util')
+
+const readFile = promisify(fs.readFile)
+const parseAsync = promisify(parse)
+
+const filepath = path.join(__dirname, 'data.csv')
+const date = new Date().toISOString()
+const userImage = 'https://s3-us-west-1.amazonaws.com/simple-blogger-react/avatar-100x100.png'
+const reviewText =
+  'Lorem ipsum dolor sit amet, consectetur adipiscing elit, sed do eiusmod tempor incididunt ut labore et dolore magna aliqua.Ut enim ad minim veniam, quis nostrud exercitation ullamco laboris nisi ut aliquip ex ea commodo consequat.'
+
+async function main() {
+  // read csv file
+  const raw = await readFile(filepath)
+
+  // parse csv in multidimensional array
+  const parsed = await parseAsync(raw)
+
+  // create post nodes
+  // trims spaces and upper case for enums
+  // skip index 0, it is the title row
+  const nodes = parsed.map((el, index) => {
+    if (index === 0) return
+    const obj1 = {
+      _typeName: 'Post',
+      id: index.toString(),
+      language: el[1].toUpperCase().trim(),
+      contentType: el[3].toUpperCase().trim(),
+      difficulty: el[7].toUpperCase().trim(),
+      title: el[4],
+      description: el[5],
+      author: el[6],
+      href: el[9],
+      image: el[10],
+      price: el[8].toUpperCase().trim(),
+      createdAt: date
+    }
+    return obj1
+  })
+
+  // tags are a list(array) and have to be sent seperately
+  // split tags on comma and trim any white space
+  const lists = parsed.map((el, index) => {
+    if (index === 0) return
+    const tags = el[2].split(',').map(tag => tag.trim())
+    const obj2 = { _typeName: 'Post', id: index.toString(), tags }
+    return obj2
+  })
+
+  // initial user
+  const user = {
+    _typeName: 'User',
+    id: '1',
+    name: 'Benjamin',
+    email: 'ben@gmail.com',
+    password: 'password',
+    image: userImage,
+    createdAt: date
+  }
+  // add user to nodes
+  nodes.push(user)
+
+  // relate each post to the user
+  const relations = parsed.map((el, index) => {
+    if (index === 0) return
+    const obj3 = { _typeName: 'User', id: '1', fieldName: 'posts' }
+    const obj4 = { _typeName: 'Post', id: index.toString(), fieldName: 'user' }
+    return [obj3, obj4]
+  })
+
+  // only needs to be defined once
+  const obj5 = { _typeName: 'User', id: '1', fieldName: 'reviews' }
+
+  // create a review for each post
+  // has random rating between 1 and 5
+  for (let i = 1; i < parsed.length; i++) {
+    const review = {
+      _typeName: 'Review',
+      id: i.toString(),
+      rating: Math.ceil(Math.random() * 5),
+      text: reviewText,
+      createdAt: date
+    }
+    nodes.push(review)
+
+    // relate each review to our user
+    // relate each review to its own post
+    // add to relations
+    const obj6 = { _typeName: 'Review', id: i.toString(), fieldName: 'user' }
+    const obj7 = { _typeName: 'Post', id: i.toString(), fieldName: 'reviews' }
+    const obj8 = { _typeName: 'Review', id: i.toString(), fieldName: 'post' }
+    const arr1 = [obj5, obj6]
+    const arr2 = [obj7, obj8]
+    relations.push(arr1)
+    relations.push(arr2)
+  }
+
+  // finalize object structure
+  // slice off null value for title row
+  const NODES = { valueType: 'nodes', values: nodes.slice(1) }
+  const LISTS = { valueType: 'lists', values: lists.slice(1) }
+  const RELATIONS = { valueType: 'relations', values: relations.slice(1) }
+
+  // send to import endpoint
+  try {
+    await sendData(NODES)
+    await sendData(LISTS)
+    await sendData(RELATIONS)
+  } catch (error) {
+    console.log(error)
+  } finally {
+    console.log(' 🌱‍ Prisma seed planted 🌱')
+  }
+}
+
+// helper function to send to import api
+// token generated from PRISMA_SERVICE_SECRET via `prisma token`
+async function sendData(data) {
+  return await axios({
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      Authorization: `Bearer ${process.env.PRISMA_TOKEN}`
+    },
+    url: `${process.env.PRISMA_ENDPOINT}/import`,
+    data
+  })
+}
+
+// fires seed function
+main()

--- a/backend/src/generated/index.d.ts
+++ b/backend/src/generated/index.d.ts
@@ -200,8 +200,8 @@ export type ReviewOrderByInput =
 export type PostOrderByInput =
   | "id_ASC"
   | "id_DESC"
-  | "langauge_ASC"
-  | "langauge_DESC"
+  | "language_ASC"
+  | "language_DESC"
   | "contentType_ASC"
   | "contentType_DESC"
   | "difficulty_ASC"
@@ -225,6 +225,10 @@ export type PostOrderByInput =
 
 export type PriceRange = "FREE" | "LOW" | "MID" | "HIGH";
 
+export type Difficulty = "EASY" | "MID" | "HARD" | "EXPERT";
+
+export type ContentType = "DOCUMENTATION" | "TUTORIAL" | "BOOK" | "ARTICLE";
+
 export type UserOrderByInput =
   | "id_ASC"
   | "id_DESC"
@@ -243,20 +247,23 @@ export type UserOrderByInput =
   | "updatedAt_ASC"
   | "updatedAt_DESC";
 
-export type Difficulty = "EASY" | "INTERMEDIATE" | "HARD" | "EXPERT";
-
-export type ContentType = "DOCUMENTATION" | "TUTORIAL" | "BOOK" | "ARTICLE";
-
-export type Library = "NATIVE" | "REACT" | "GRAPHQL" | "NEXT";
-
-export type Language = "JAVASCRIPT" | "PYTHON" | "CPLUSPLUS";
+export type Language =
+  | "JAVASCRIPT"
+  | "PYTHON"
+  | "CSHARP"
+  | "CSS"
+  | "CLI"
+  | "LINUX"
+  | "AWS"
+  | "GIT"
+  | "JAVA"
+  | "MARKDOWN";
 
 export type MutationType = "CREATED" | "UPDATED" | "DELETED";
 
-export interface ReviewCreateWithoutUserInput {
-  rating: Int;
-  text?: String;
-  post: PostCreateOneWithoutReviewsInput;
+export interface PostCreateOneWithoutReviewsInput {
+  create?: PostCreateWithoutReviewsInput;
+  connect?: PostWhereUniqueInput;
 }
 
 export type PostWhereUniqueInput = AtLeastOne<{
@@ -383,8 +390,8 @@ export interface ReviewUpdateWithWhereUniqueWithoutUserInput {
 }
 
 export interface PostCreateWithoutUserInput {
-  langauge: Language;
-  library?: PostCreatelibraryInput;
+  language: Language;
+  tags?: PostCreatetagsInput;
   contentType: ContentType;
   difficulty: Difficulty;
   title: String;
@@ -453,11 +460,10 @@ export interface UserUpdateInput {
   reviews?: ReviewUpdateManyWithoutUserInput;
 }
 
-export interface PostUpdateOneRequiredWithoutReviewsInput {
-  create?: PostCreateWithoutReviewsInput;
-  update?: PostUpdateWithoutReviewsDataInput;
-  upsert?: PostUpsertWithoutReviewsInput;
-  connect?: PostWhereUniqueInput;
+export interface ReviewCreateWithoutUserInput {
+  rating: Int;
+  text?: String;
+  post: PostCreateOneWithoutReviewsInput;
 }
 
 export interface ReviewUpdateManyMutationInput {
@@ -465,8 +471,10 @@ export interface ReviewUpdateManyMutationInput {
   text?: String;
 }
 
-export interface PostCreateOneWithoutReviewsInput {
+export interface PostUpdateOneRequiredWithoutReviewsInput {
   create?: PostCreateWithoutReviewsInput;
+  update?: PostUpdateWithoutReviewsDataInput;
+  upsert?: PostUpsertWithoutReviewsInput;
   connect?: PostWhereUniqueInput;
 }
 
@@ -478,8 +486,8 @@ export interface ReviewUpdateInput {
 }
 
 export interface PostCreateWithoutReviewsInput {
-  langauge: Language;
-  library?: PostCreatelibraryInput;
+  language: Language;
+  tags?: PostCreatetagsInput;
   contentType: ContentType;
   difficulty: Difficulty;
   title: String;
@@ -492,8 +500,8 @@ export interface PostCreateWithoutReviewsInput {
 }
 
 export interface PostUpdateManyMutationInput {
-  langauge?: Language;
-  library?: PostUpdatelibraryInput;
+  language?: Language;
+  tags?: PostUpdatetagsInput;
   contentType?: ContentType;
   difficulty?: Difficulty;
   title?: String;
@@ -505,8 +513,8 @@ export interface PostUpdateManyMutationInput {
 }
 
 export interface PostUpdateInput {
-  langauge?: Language;
-  library?: PostUpdatelibraryInput;
+  language?: Language;
+  tags?: PostUpdatetagsInput;
   contentType?: ContentType;
   difficulty?: Difficulty;
   title?: String;
@@ -524,8 +532,8 @@ export interface UserUpsertWithoutPostsInput {
   create: UserCreateWithoutPostsInput;
 }
 
-export interface PostUpdatelibraryInput {
-  set?: Library[] | Library;
+export interface PostUpdatetagsInput {
+  set?: String[] | String;
 }
 
 export interface PostUpsertWithoutReviewsInput {
@@ -546,8 +554,8 @@ export interface ReviewUpdateManyWithoutPostInput {
     | ReviewUpsertWithWhereUniqueWithoutPostInput;
 }
 
-export interface PostCreatelibraryInput {
-  set?: Library[] | Library;
+export interface PostCreatetagsInput {
+  set?: String[] | String;
 }
 
 export interface PostWhereInput {
@@ -565,10 +573,10 @@ export interface PostWhereInput {
   id_not_starts_with?: ID_Input;
   id_ends_with?: ID_Input;
   id_not_ends_with?: ID_Input;
-  langauge?: Language;
-  langauge_not?: Language;
-  langauge_in?: Language[] | Language;
-  langauge_not_in?: Language[] | Language;
+  language?: Language;
+  language_not?: Language;
+  language_in?: Language[] | Language;
+  language_not_in?: Language[] | Language;
   contentType?: ContentType;
   contentType_not?: ContentType;
   contentType_in?: ContentType[] | ContentType;
@@ -799,8 +807,8 @@ export interface ReviewUpsertWithWhereUniqueWithoutUserInput {
 }
 
 export interface PostUpdateWithoutUserDataInput {
-  langauge?: Language;
-  library?: PostUpdatelibraryInput;
+  language?: Language;
+  tags?: PostUpdatetagsInput;
   contentType?: ContentType;
   difficulty?: Difficulty;
   title?: String;
@@ -813,8 +821,8 @@ export interface PostUpdateWithoutUserDataInput {
 }
 
 export interface PostCreateInput {
-  langauge: Language;
-  library?: PostCreatelibraryInput;
+  language: Language;
+  tags?: PostCreatetagsInput;
   contentType: ContentType;
   difficulty: Difficulty;
   title: String;
@@ -907,8 +915,8 @@ export interface ReviewCreateManyWithoutPostInput {
 }
 
 export interface PostUpdateWithoutReviewsDataInput {
-  langauge?: Language;
-  library?: PostUpdatelibraryInput;
+  language?: Language;
+  tags?: PostUpdatetagsInput;
   contentType?: ContentType;
   difficulty?: Difficulty;
   title?: String;
@@ -1233,8 +1241,8 @@ export interface ReviewEdgeSubscription
 
 export interface PostPreviousValues {
   id: ID_Output;
-  langauge: Language;
-  library: Library[];
+  language: Language;
+  tags: String[];
   contentType: ContentType;
   difficulty: Difficulty;
   title: String;
@@ -1250,8 +1258,8 @@ export interface PostPreviousValuesPromise
   extends Promise<PostPreviousValues>,
     Fragmentable {
   id: () => Promise<ID_Output>;
-  langauge: () => Promise<Language>;
-  library: () => Promise<Library[]>;
+  language: () => Promise<Language>;
+  tags: () => Promise<String[]>;
   contentType: () => Promise<ContentType>;
   difficulty: () => Promise<Difficulty>;
   title: () => Promise<String>;
@@ -1267,8 +1275,8 @@ export interface PostPreviousValuesSubscription
   extends Promise<AsyncIterator<PostPreviousValues>>,
     Fragmentable {
   id: () => Promise<AsyncIterator<ID_Output>>;
-  langauge: () => Promise<AsyncIterator<Language>>;
-  library: () => Promise<AsyncIterator<Library[]>>;
+  language: () => Promise<AsyncIterator<Language>>;
+  tags: () => Promise<AsyncIterator<String[]>>;
   contentType: () => Promise<AsyncIterator<ContentType>>;
   difficulty: () => Promise<AsyncIterator<Difficulty>>;
   title: () => Promise<AsyncIterator<String>>;
@@ -1305,8 +1313,8 @@ export interface PostSubscriptionPayloadSubscription
 
 export interface Post {
   id: ID_Output;
-  langauge: Language;
-  library: Library[];
+  language: Language;
+  tags: String[];
   contentType: ContentType;
   difficulty: Difficulty;
   title: String;
@@ -1320,8 +1328,8 @@ export interface Post {
 
 export interface PostPromise extends Promise<Post>, Fragmentable {
   id: () => Promise<ID_Output>;
-  langauge: () => Promise<Language>;
-  library: () => Promise<Library[]>;
+  language: () => Promise<Language>;
+  tags: () => Promise<String[]>;
   contentType: () => Promise<ContentType>;
   difficulty: () => Promise<Difficulty>;
   title: () => Promise<String>;
@@ -1349,8 +1357,8 @@ export interface PostSubscription
   extends Promise<AsyncIterator<Post>>,
     Fragmentable {
   id: () => Promise<AsyncIterator<ID_Output>>;
-  langauge: () => Promise<AsyncIterator<Language>>;
-  library: () => Promise<AsyncIterator<Library[]>>;
+  language: () => Promise<AsyncIterator<Language>>;
+  tags: () => Promise<AsyncIterator<String[]>>;
   contentType: () => Promise<AsyncIterator<ContentType>>;
   difficulty: () => Promise<AsyncIterator<Difficulty>>;
   title: () => Promise<AsyncIterator<String>>;
@@ -1517,10 +1525,6 @@ export const models = [
   },
   {
     name: "Language",
-    embedded: false
-  },
-  {
-    name: "Library",
     embedded: false
   },
   {

--- a/backend/src/generated/index.js
+++ b/backend/src/generated/index.js
@@ -17,10 +17,6 @@ var models = [
     embedded: false
   },
   {
-    name: "Library",
-    embedded: false
-  },
-  {
     name: "Post",
     embedded: false
   },
@@ -40,6 +36,7 @@ var models = [
 exports.Prisma = prisma_lib_1.makePrismaClientClass({
   typeDefs,
   models,
-  endpoint: `${process.env["PRISMA_ENDPOINT"]}`
+  endpoint: `${process.env["PRISMA_ENDPOINT"]}`,
+  secret: `${process.env["PRISMA_SERVICE_SECRET"]}`
 });
 exports.prisma = new exports.Prisma();

--- a/backend/src/generated/prisma-schema.js
+++ b/backend/src/generated/prisma-schema.js
@@ -26,7 +26,7 @@ scalar DateTime
 
 enum Difficulty {
   EASY
-  INTERMEDIATE
+  MID
   HARD
   EXPERT
 }
@@ -34,14 +34,14 @@ enum Difficulty {
 enum Language {
   JAVASCRIPT
   PYTHON
-  CPLUSPLUS
-}
-
-enum Library {
-  NATIVE
-  REACT
-  GRAPHQL
-  NEXT
+  CSHARP
+  CSS
+  CLI
+  LINUX
+  AWS
+  GIT
+  JAVA
+  MARKDOWN
 }
 
 scalar Long
@@ -86,8 +86,8 @@ type PageInfo {
 
 type Post {
   id: ID!
-  langauge: Language!
-  library: [Library!]!
+  language: Language!
+  tags: [String!]!
   contentType: ContentType!
   difficulty: Difficulty!
   title: String!
@@ -108,8 +108,8 @@ type PostConnection {
 }
 
 input PostCreateInput {
-  langauge: Language!
-  library: PostCreatelibraryInput
+  language: Language!
+  tags: PostCreatetagsInput
   contentType: ContentType!
   difficulty: Difficulty!
   title: String!
@@ -122,10 +122,6 @@ input PostCreateInput {
   user: UserCreateOneWithoutPostsInput!
 }
 
-input PostCreatelibraryInput {
-  set: [Library!]
-}
-
 input PostCreateManyWithoutUserInput {
   create: [PostCreateWithoutUserInput!]
   connect: [PostWhereUniqueInput!]
@@ -136,9 +132,13 @@ input PostCreateOneWithoutReviewsInput {
   connect: PostWhereUniqueInput
 }
 
+input PostCreatetagsInput {
+  set: [String!]
+}
+
 input PostCreateWithoutReviewsInput {
-  langauge: Language!
-  library: PostCreatelibraryInput
+  language: Language!
+  tags: PostCreatetagsInput
   contentType: ContentType!
   difficulty: Difficulty!
   title: String!
@@ -151,8 +151,8 @@ input PostCreateWithoutReviewsInput {
 }
 
 input PostCreateWithoutUserInput {
-  langauge: Language!
-  library: PostCreatelibraryInput
+  language: Language!
+  tags: PostCreatetagsInput
   contentType: ContentType!
   difficulty: Difficulty!
   title: String!
@@ -172,8 +172,8 @@ type PostEdge {
 enum PostOrderByInput {
   id_ASC
   id_DESC
-  langauge_ASC
-  langauge_DESC
+  language_ASC
+  language_DESC
   contentType_ASC
   contentType_DESC
   difficulty_ASC
@@ -198,8 +198,8 @@ enum PostOrderByInput {
 
 type PostPreviousValues {
   id: ID!
-  langauge: Language!
-  library: [Library!]!
+  language: Language!
+  tags: [String!]!
   contentType: ContentType!
   difficulty: Difficulty!
   title: String!
@@ -230,8 +230,8 @@ input PostSubscriptionWhereInput {
 }
 
 input PostUpdateInput {
-  langauge: Language
-  library: PostUpdatelibraryInput
+  language: Language
+  tags: PostUpdatetagsInput
   contentType: ContentType
   difficulty: Difficulty
   title: String
@@ -244,13 +244,9 @@ input PostUpdateInput {
   user: UserUpdateOneRequiredWithoutPostsInput
 }
 
-input PostUpdatelibraryInput {
-  set: [Library!]
-}
-
 input PostUpdateManyMutationInput {
-  langauge: Language
-  library: PostUpdatelibraryInput
+  language: Language
+  tags: PostUpdatetagsInput
   contentType: ContentType
   difficulty: Difficulty
   title: String
@@ -277,9 +273,13 @@ input PostUpdateOneRequiredWithoutReviewsInput {
   connect: PostWhereUniqueInput
 }
 
+input PostUpdatetagsInput {
+  set: [String!]
+}
+
 input PostUpdateWithoutReviewsDataInput {
-  langauge: Language
-  library: PostUpdatelibraryInput
+  language: Language
+  tags: PostUpdatetagsInput
   contentType: ContentType
   difficulty: Difficulty
   title: String
@@ -292,8 +292,8 @@ input PostUpdateWithoutReviewsDataInput {
 }
 
 input PostUpdateWithoutUserDataInput {
-  langauge: Language
-  library: PostUpdatelibraryInput
+  language: Language
+  tags: PostUpdatetagsInput
   contentType: ContentType
   difficulty: Difficulty
   title: String
@@ -336,10 +336,10 @@ input PostWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
-  langauge: Language
-  langauge_not: Language
-  langauge_in: [Language!]
-  langauge_not_in: [Language!]
+  language: Language
+  language_not: Language
+  language_in: [Language!]
+  language_not_in: [Language!]
   contentType: ContentType
   contentType_not: ContentType
   contentType_in: [ContentType!]

--- a/backend/src/generated/prisma.graphql
+++ b/backend/src/generated/prisma.graphql
@@ -25,7 +25,7 @@ scalar DateTime
 
 enum Difficulty {
   EASY
-  INTERMEDIATE
+  MID
   HARD
   EXPERT
 }
@@ -33,14 +33,14 @@ enum Difficulty {
 enum Language {
   JAVASCRIPT
   PYTHON
-  CPLUSPLUS
-}
-
-enum Library {
-  NATIVE
-  REACT
-  GRAPHQL
-  NEXT
+  CSHARP
+  CSS
+  CLI
+  LINUX
+  AWS
+  GIT
+  JAVA
+  MARKDOWN
 }
 
 scalar Long
@@ -85,8 +85,8 @@ type PageInfo {
 
 type Post {
   id: ID!
-  langauge: Language!
-  library: [Library!]!
+  language: Language!
+  tags: [String!]!
   contentType: ContentType!
   difficulty: Difficulty!
   title: String!
@@ -107,8 +107,8 @@ type PostConnection {
 }
 
 input PostCreateInput {
-  langauge: Language!
-  library: PostCreatelibraryInput
+  language: Language!
+  tags: PostCreatetagsInput
   contentType: ContentType!
   difficulty: Difficulty!
   title: String!
@@ -121,10 +121,6 @@ input PostCreateInput {
   user: UserCreateOneWithoutPostsInput!
 }
 
-input PostCreatelibraryInput {
-  set: [Library!]
-}
-
 input PostCreateManyWithoutUserInput {
   create: [PostCreateWithoutUserInput!]
   connect: [PostWhereUniqueInput!]
@@ -135,9 +131,13 @@ input PostCreateOneWithoutReviewsInput {
   connect: PostWhereUniqueInput
 }
 
+input PostCreatetagsInput {
+  set: [String!]
+}
+
 input PostCreateWithoutReviewsInput {
-  langauge: Language!
-  library: PostCreatelibraryInput
+  language: Language!
+  tags: PostCreatetagsInput
   contentType: ContentType!
   difficulty: Difficulty!
   title: String!
@@ -150,8 +150,8 @@ input PostCreateWithoutReviewsInput {
 }
 
 input PostCreateWithoutUserInput {
-  langauge: Language!
-  library: PostCreatelibraryInput
+  language: Language!
+  tags: PostCreatetagsInput
   contentType: ContentType!
   difficulty: Difficulty!
   title: String!
@@ -171,8 +171,8 @@ type PostEdge {
 enum PostOrderByInput {
   id_ASC
   id_DESC
-  langauge_ASC
-  langauge_DESC
+  language_ASC
+  language_DESC
   contentType_ASC
   contentType_DESC
   difficulty_ASC
@@ -197,8 +197,8 @@ enum PostOrderByInput {
 
 type PostPreviousValues {
   id: ID!
-  langauge: Language!
-  library: [Library!]!
+  language: Language!
+  tags: [String!]!
   contentType: ContentType!
   difficulty: Difficulty!
   title: String!
@@ -229,8 +229,8 @@ input PostSubscriptionWhereInput {
 }
 
 input PostUpdateInput {
-  langauge: Language
-  library: PostUpdatelibraryInput
+  language: Language
+  tags: PostUpdatetagsInput
   contentType: ContentType
   difficulty: Difficulty
   title: String
@@ -243,13 +243,9 @@ input PostUpdateInput {
   user: UserUpdateOneRequiredWithoutPostsInput
 }
 
-input PostUpdatelibraryInput {
-  set: [Library!]
-}
-
 input PostUpdateManyMutationInput {
-  langauge: Language
-  library: PostUpdatelibraryInput
+  language: Language
+  tags: PostUpdatetagsInput
   contentType: ContentType
   difficulty: Difficulty
   title: String
@@ -276,9 +272,13 @@ input PostUpdateOneRequiredWithoutReviewsInput {
   connect: PostWhereUniqueInput
 }
 
+input PostUpdatetagsInput {
+  set: [String!]
+}
+
 input PostUpdateWithoutReviewsDataInput {
-  langauge: Language
-  library: PostUpdatelibraryInput
+  language: Language
+  tags: PostUpdatetagsInput
   contentType: ContentType
   difficulty: Difficulty
   title: String
@@ -291,8 +291,8 @@ input PostUpdateWithoutReviewsDataInput {
 }
 
 input PostUpdateWithoutUserDataInput {
-  langauge: Language
-  library: PostUpdatelibraryInput
+  language: Language
+  tags: PostUpdatetagsInput
   contentType: ContentType
   difficulty: Difficulty
   title: String
@@ -335,10 +335,10 @@ input PostWhereInput {
   id_not_starts_with: ID
   id_ends_with: ID
   id_not_ends_with: ID
-  langauge: Language
-  langauge_not: Language
-  langauge_in: [Language!]
-  langauge_not_in: [Language!]
+  language: Language
+  language_not: Language
+  language_in: [Language!]
+  language_not_in: [Language!]
   contentType: ContentType
   contentType_not: ContentType
   contentType_in: [ContentType!]

--- a/backend/src/schema.graphql
+++ b/backend/src/schema.graphql
@@ -6,9 +6,72 @@ type User {
   email: String!
   image: String
   password: String
+  oauthId: String
+  posts: [Post]
+  reviews: [Review]
   createdAt: DateTime!
 }
 
-type Query {
-  users: [User]
+type Post {
+  id: ID!
+  language: Language!
+  tags: [String!]!
+  contentType: ContentType!
+  difficulty: Difficulty!
+  title: String!
+  description: String!
+  author: String
+  href: String!
+  image: String
+  price: PriceRange!
+  reviews: [Review]!
+  user: User!
+  createdAt: DateTime!
+}
+
+type Review {
+  id: ID!
+  rating: Int!
+  text: String
+  user: User!
+  post: Post!
+  createdAt: DateTime!
+}
+
+# various programming languages
+enum Language {
+  JAVASCRIPT
+  PYTHON
+  CSHARP
+  CSS
+  CLI
+  LINUX
+  AWS
+  GIT
+  JAVA
+  MARKDOWN
+}
+
+# general categories of content
+enum ContentType {
+  DOCUMENTATION
+  TUTORIAL
+  BOOK
+  ARTICLE
+}
+
+# difficulty level of content
+enum Difficulty {
+  EASY
+  INTERMEDIATE
+  HARD
+  EXPERT
+}
+
+# price range
+enum PriceRange {
+  FREE
+  LOW
+  MID
+  HIGH
 }


### PR DESCRIPTION
- `npm run seed` will clear all data in the database and seed it with posts from a csv file
- also generates one user & one review for each post
- csv file is meant to be exported from Sheets and placed at  `~backend/seed/data.csv` 
- adds `*.csv` to `.gitignore`