### PR TITLE
:lipstick: add basic grid scss to the signin and signup pages

### DIFF
--- a/frontend/components/Signin.js
+++ b/frontend/components/Signin.js
@@ -34,29 +34,25 @@ class Signin extends Component {
     return (
       <Mutation mutation={SIGNIN_MUTATION}>
         {(signin, { data, loading, error }) => (
-          <form>
+          <form className="signin-form">
             <h2>Sign into your account</h2>
-            <label htmlFor="email">
-              Email
-              <input
-                type="email"
-                name="email"
-                placeholder="email"
-                value={this.state.email}
-                onChange={this.saveToState}
-              />
-            </label>
+            <label htmlFor="email">Email</label>
+            <input
+              type="email"
+              name="email"
+              placeholder="email"
+              value={this.state.email}
+              onChange={this.saveToState}
+            />
 
-            <label htmlFor="password">
-              Password
-              <input
-                type="password"
-                name="password"
-                placeholder="password"
-                value={this.state.password}
-                onChange={this.saveToState}
-              />
-            </label>
+            <label htmlFor="password">Password</label>
+            <input
+              type="password"
+              name="password"
+              placeholder="password"
+              value={this.state.password}
+              onChange={this.saveToState}
+            />
             <button type="submit">Login</button>
             <br />
             {data && <div>{JSON.stringify(data)}</div>}

--- a/frontend/components/Signup.js
+++ b/frontend/components/Signup.js
@@ -37,42 +37,47 @@ class Signup extends Component {
     return (
       <Mutation mutation={SIGNUP_MUTATION}>
         {(signup, { data, loading, error }) => (
-          <form method="POST" onSubmit={e => this.handleSubmit(e, signup)}>
+          <form className="signup-form" method="POST" onSubmit={e => this.handleSubmit(e, signup)}>
             <h2>Sign Up for An Account</h2>
-            <label htmlFor="email">
+            <label className="signup-email-label" htmlFor="email">
               Email
-              <input
-                type="email"
-                name="email"
-                placeholder="email"
-                value={this.state.email}
-                onChange={this.saveToState}
-              />
             </label>
+            <input
+              className="signup-email-input"
+              type="email"
+              name="email"
+              placeholder="email"
+              value={this.state.email}
+              onChange={this.saveToState}
+            />
 
-            <label htmlFor="name">
+            <label className="signup-name-label" htmlFor="name">
               Name
-              <input
-                type="text"
-                name="name"
-                placeholder="name"
-                value={this.state.name}
-                onChange={this.saveToState}
-              />
             </label>
+            <input
+              className="signup-name-input"
+              type="text"
+              name="name"
+              placeholder="name"
+              value={this.state.name}
+              onChange={this.saveToState}
+            />
 
-            <label htmlFor="password">
+            <label className="signup-password-label" htmlFor="password">
               Password
-              <input
-                type="password"
-                name="password"
-                placeholder="password"
-                value={this.state.password}
-                onChange={this.saveToState}
-              />
             </label>
+            <input
+              className="signup-password-input"
+              type="password"
+              name="password"
+              placeholder="password"
+              value={this.state.password}
+              onChange={this.saveToState}
+            />
 
-            <button type="submit">Sign Up!</button>
+            <button className="signup-button" type="submit">
+              Sign Up!
+            </button>
             <br />
             <DisplayError error={error} />
           </form>

--- a/frontend/styles/pages/signin.scss
+++ b/frontend/styles/pages/signin.scss
@@ -1,0 +1,15 @@
+.signin-form{
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    grid-gap: 16px;
+    max-width: 400px;
+    padding: 1em;
+}
+.signin-form label {
+    grid-column: 1 / 2;
+}
+ 
+.signin-form input,
+.signin-form button {
+    grid-column: 2 / 3;
+}

--- a/frontend/styles/pages/signup.scss
+++ b/frontend/styles/pages/signup.scss
@@ -1,0 +1,44 @@
+.signup-form{
+    display: grid;
+    grid-template-columns: 200px 1fr;
+    grid-gap: 16px;
+    max-width: 400px;
+    padding: 1em;
+}
+
+.signup-form label {
+    grid-column: 1 / 2;
+}
+ 
+.signup-form input,
+.signup-form button {
+    grid-column: 2 / 3;
+}
+
+/* .signup-email-label{
+
+}
+
+.signup-name-label{
+    
+}
+
+.signup-password-label{
+    
+}
+
+.signup-email-input{
+    
+}
+
+.signup-name-input{
+    
+}
+
+.signup-password-input{
+    
+}
+
+.signup-button{
+
+} */


### PR DESCRIPTION
# Description

Added some basic styling to the sign in and signup pages. Inputs are no longer children of labels. Please check that this does not break functionality. 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)(Maybe)
## Change status
- [x] Complete, tested, ready to review and merge (Compiles)
- [x] Complete, but not tested (may need new tests) (Test the inputs!)
- [x] Incomplete/work-in-progress, PR is for discussion/feedback

# How Has This Been Tested?

Compiles

# Checklist:

- [x] My code follows the style guidelines of this project(I think so)
- [x] I have performed a self-review of my own code
- [x] My changes generate no new warnings
- [x] There are no merge conflicts