### PR TITLE
:recycle: Refactor Search into Wrapper component

### DIFF
--- a/frontend/components/Filters.js
+++ b/frontend/components/Filters.js
@@ -1,0 +1,54 @@
+import formatPrice from '../lib/formatPrice'
+import { PRICE, DIFFICULTY, ORDER_BY } from '../lib/filterConstants'
+
+export default ({
+  client,
+  price,
+  difficulty,
+  orderBy,
+  handlePrice,
+  handleDifficulty,
+  handleOrderBy,
+}) => (
+  <div className="filter">
+    <div className="filter__price">
+      {PRICE.map(p => (
+        <span
+          key={p}
+          className="filter__price__option"
+          onClick={() => handlePrice(p, client)}
+          style={{
+            background: price.includes(p) && '#306AFD',
+            color: price.includes(p) && 'white',
+          }}
+        >
+          {formatPrice(p)}
+        </span>
+      ))}
+    </div>
+
+    <div className="filter__difficulty">
+      {DIFFICULTY.map(d => (
+        <span
+          key={d}
+          className="filter__difficulty__option"
+          onClick={() => handleDifficulty(d, client)}
+          style={{
+            background: difficulty.includes(d) && '#306AFD',
+            color: difficulty.includes(d) && 'white',
+          }}
+        >
+          {d}
+        </span>
+      ))}
+    </div>
+
+    <select className="filter__orderBy" value={orderBy} onChange={handleOrderBy}>
+      {ORDER_BY.map(o => (
+        <option key={o.text} value={o.value}>
+          {o.text}
+        </option>
+      ))}
+    </select>
+  </div>
+)

--- a/frontend/components/InnerHeader.js
+++ b/frontend/components/InnerHeader.js
@@ -11,7 +11,12 @@ const InnerHeader = props => (
         <span className="logo__curly">&#125;</span>
       </a>
     </Link>
-    <Search client={props.client} term={props.term} handleChange={props.handleChange} />
+    <Search
+      client={props.client}
+      term={props.term}
+      handleChange={props.handleChange}
+      handleClick={props.handleClick}
+    />
     <Nav />
   </header>
 )

--- a/frontend/components/Posts.js
+++ b/frontend/components/Posts.js
@@ -1,213 +1,14 @@
 import React from 'react'
-import { ApolloConsumer, withApollo } from 'react-apollo'
-import gql from 'graphql-tag'
-import StarRatingComponent from 'react-star-rating-component'
 import Router from 'next/router'
-import debounce from 'lodash.debounce'
-import isEqual from 'lodash.isequal'
-import InnerHeader from './InnerHeader'
+import StarRatingComponent from 'react-star-rating-component'
+import formatPrice from '../lib/formatPrice'
 import averageRating from '../lib/averageRating'
 
-// max number of posts returned per page
-const perPage = 30
-
-// the mongoloid
-const SEARCH_POSTS_QUERY = gql`
-  query SEARCH_POSTS_QUERY(
-    $term: String,
-    $difficulty: [Difficulty!],
-    $price: [PriceRange!],
-    $first: Int = ${perPage},
-    $skip: Int = 0,
-    $orderBy: PostOrderByInput = title_ASC
-    ) {
-    posts(
-      where: {
-        AND: [
-          { difficulty_in: $difficulty },
-          { price_in: $price }
-          {
-            OR: [
-            { title_contains: $term },
-            { description_contains: $term },
-            { author_contains: $term }
-            ]
-          }
-
-        ]
-
-      },
-      first: $first,
-      skip: $skip,
-      orderBy: $orderBy) {
-      id
-      title
-      description
-      language
-      contentType
-      tags
-      image
-      href
-      author
-      difficulty
-      price
-      createdAt
-      reviews {
-        id
-        text
-        rating
-        createdAt
-      }
-    }
-  }
-`
-// order by filters
-const ORDER_BY = [
-  { text: 'Alphabetical', value: 0 },
-  { text: 'Highest Rating', value: 1 },
-  { text: 'Most Reviewed', value: 2 },
-]
-// difficulty filters
-const DIFFICULTY = ['EASY', 'MID', 'HARD', 'EXPERT']
-
-// price filters
-const PRICE = ['FREE', 'LOW', 'MID', 'HIGH']
-const formatPriceLabel = p => {
-  const i = PRICE.indexOf(p)
-  if (i === 0) return 'FREE'
-  if (i === 1) return '$'
-  if (i === 2) return '$$'
-  if (i === 3) return '$$$'
-  return null
-}
-
-// stops empty array going to query
-// makes default search for all filters
-function getQueryValue(arr, i) {
-  const params = [DIFFICULTY, PRICE]
-  if (!arr.length) {
-    return params[i]
-  }
-  return arr
-}
-
-class Posts extends React.Component {
-  state = {
-    loading: false,
-    posts: [],
-    avgs: [],
-    term: '',
-    price: [],
-    difficulty: [],
-    orderBy: 0,
+export default class Posts extends React.Component {
+  onPostClick = id => {
+    Router.push({ pathname: '/post', query: { id } })
   }
 
-  // adds listener for internal route change
-  componentDidMount() {
-    Router.events.on('routeChangeStart', this.handleRouteChange)
-    this.restoreSearchParams()
-  }
-
-  // clean up for event listeners
-  componentWillUnmount() {
-    Router.events.off('routeChangeStart', this.handleRouteChange)
-  }
-
-  // deep equal check on posts array
-  // when posts change find the average rating and rebuild post w/Object.assign
-  componentDidUpdate(prevProps, prevState) {
-    if (!isEqual(prevState.posts, this.state.posts)) {
-      const avgs = this.state.posts.map(post => averageRating(post.reviews))
-      const postsWithAvg = this.state.posts.map((post, i) =>
-        Object.assign({}, post, { averageRating: avgs[i] }))
-      this.setState({ posts: postsWithAvg })
-    }
-  }
-
-  // debounce to .5s against user key input
-  handleChange = debounce(async (term, client) => {
-    if (!term) return this.setState({ posts: [], term })
-    this.setState({ loading: true, term })
-    // if no difficulty is selected act as if they all are
-    const difficulty = this.state.difficulty.length ? this.state.difficulty : DIFFICULTY
-    // query the prisma client directly
-    const res = await client.query({
-      query: SEARCH_POSTS_QUERY,
-      variables: { term, difficulty },
-    })
-    return this.setState({ loading: false, posts: res.data.posts })
-  }, 500)
-
-  // refetch query when user changes price array
-  handlePrice = async (p, client) => {
-    this.setState({ loading: true })
-    const { difficulty } = this.state
-    let { price } = this.state
-
-    if (price.includes(p)) {
-      price = price.filter(el => el !== p)
-    } else {
-      price.push(p)
-    }
-
-    const queryPrice = getQueryValue(price, 1)
-    const queryDifficulty = getQueryValue(difficulty, 0)
-
-    const res = await client.query({
-      query: SEARCH_POSTS_QUERY,
-      variables: { term: this.state.term, price: queryPrice, difficulty: queryDifficulty },
-    })
-
-    this.setState({ loading: false, price, posts: res.data.posts })
-  }
-
-  // refetch every time user changes difficulty array
-  handleDifficulty = async (d, client) => {
-    this.setState({ loading: true })
-    const { price } = this.state
-    let { difficulty } = this.state
-    // filter or replace based on pre existance
-    if (difficulty.includes(d)) {
-      difficulty = difficulty.filter(el => el !== d)
-    } else {
-      difficulty.push(d)
-    }
-    // check to see if none are checked
-    const queryPrice = getQueryValue(price, 1)
-    const queryDifficulty = getQueryValue(difficulty, 0)
-    // query prisma with both search term and difficulty
-    const res = await client.query({
-      query: SEARCH_POSTS_QUERY,
-      variables: { term: this.state.term, difficulty: queryDifficulty, price: queryPrice },
-    })
-    this.setState({ loading: false, difficulty, posts: res.data.posts })
-  }
-
-  // no query to prisma here, just sort what we have
-  handleOrderBy = e => {
-    const orderBy = Number(e.target.value)
-    const { posts } = this.state
-    let sortedPosts
-    // simple alphabetical sort this is default for now
-    if (orderBy === 0) {
-      sortedPosts = posts.sort((a, b) => {
-        const x = a.title.toLowerCase()
-        const y = b.title.toLowerCase()
-        if (x < y) return -1
-        if (x > y) return 1
-        return 0
-      })
-      // find the averages and sort from highest to lowest average
-    } else if (orderBy === 1) {
-      sortedPosts = posts.sort((a, b) => averageRating(b.reviews) - averageRating(a.reviews))
-      // count reviews and sort from most to least
-    } else {
-      sortedPosts = posts.sort((a, b) => b.reviews.length - a.reviews.length)
-    }
-    this.setState({ posts: sortedPosts, orderBy })
-  }
-
-  // helper to render tag strings
   renderTags = tags =>
     tags.map((tag, i) => {
       if (i > 6) return null
@@ -218,178 +19,74 @@ class Posts extends React.Component {
       )
     })
 
-  // turns numeric rating to fire emojis
-  renderRating = x => {
-    let str = ''
-    for (let i = 0; i < x; i += 1) {
-      str += '🔥'
-    }
-    return <span>{str}</span>
-  }
-
-  // navigate to post detail route
-  onPostClick = id => {
-    Router.push({ pathname: '/post', query: { id } })
-  }
-
-  // stores search criteria in session storage
-  handleRouteChange = () => {
-    const { term, difficulty, price, orderBy } = this.state
-    const params = { term, difficulty, price, orderBy }
-    sessionStorage.setItem('parameters', JSON.stringify(params)) // eslint-disable-line
-  }
-
-  // restores posts using withApollo HOC and session storage
-  restoreSearchParams = async () => {
-    const params = JSON.parse(sessionStorage.getItem('parameters')) // eslint-disable-line
-    if (!params) return
-
-    const { term, difficulty, price, orderBy } = params
-    const queryPrice = getQueryValue(price, 1)
-    const queryDifficulty = getQueryValue(difficulty, 0)
-
-    const res = await this.props.client.query({
-      query: SEARCH_POSTS_QUERY,
-      variables: {
-        term,
-        difficulty: queryDifficulty,
-        price: queryPrice,
-      },
-    })
-
-    const fakeEvent = { target: { value: orderBy } }
-    this.handleOrderBy(fakeEvent)
-
-    this.setState({
-      term,
-      difficulty,
-      price,
-      posts: res.data.posts,
-      orderBy,
-    })
-  }
-
   render() {
+    const {
+      props: { loading, posts, term },
+    } = this
+
     return (
-      <ApolloConsumer>
-        {client => (
-          <div className="posts__component">
-            <InnerHeader client={client} term={this.state.term} handleChange={this.handleChange} />
-
-            <div className="filter">
-              <div className="filter__price">
-                {PRICE.map(p => (
-                  <span
-                    key={p}
-                    className="filter__price__option"
-                    onClick={() => this.handlePrice(p, client)}
-                    style={{
-                      background: this.state.price.includes(p) && '#306AFD',
-                      color: this.state.price.includes(p) && 'white',
-                    }}
-                  >
-                    {formatPriceLabel(p)}
+      <div className="posts">
+        <div className="posts__message">
+          {!!posts.length && !loading && (
+            <p>
+              Browsing <span>[</span>"{term}"<span>]</span>
+            </p>
+          )}
+        </div>
+        <div className="posts__grid">
+          {posts.map((post, i) => (
+            <div className="post" key={post.id}>
+              <img
+                src={post.image}
+                width="100"
+                height="100"
+                onClick={() => this.onPostClick(post.id)}
+              />
+              <div className="post__info">
+                <p className="post__info__title" onClick={() => this.onPostClick(post.id)}>
+                  {post.title}
+                </p>
+                <div className="post__info__middle">
+                  <StarRatingComponent
+                    className="post__info__rating"
+                    name="rating"
+                    value={averageRating(post.reviews)}
+                    emptyStarColor="#eee"
+                  />
+                  <p className="post__info__author">{post.author}</p>
+                </div>
+                <div className="post__info__tags">{this.renderTags(post.tags)}</div>
+              </div>
+              <div className="post__details">
+                <div className="post__details__row">
+                  <span>Language</span>
+                  <span>
+                    <b>[</b> {post.language} <b>]</b>
                   </span>
-                ))}
-              </div>
-
-              <div className="filter__difficulty">
-                {DIFFICULTY.map(d => (
-                  <span
-                    key={d}
-                    className="filter__difficulty__option"
-                    onClick={() => this.handleDifficulty(d, client)}
-                    style={{
-                      background: this.state.difficulty.includes(d) && '#306AFD',
-                      color: this.state.difficulty.includes(d) && 'white',
-                    }}
-                  >
-                    {d}
+                </div>
+                <div className="post__details__row">
+                  <span>Difficulty</span>
+                  <span>
+                    <b>[</b> {post.difficulty} <b>]</b>
                   </span>
-                ))}
-              </div>
-
-              <select
-                className="filter__orderBy"
-                value={this.state.orderBy}
-                onChange={this.handleOrderBy}
-              >
-                {ORDER_BY.map(o => (
-                  <option key={o.text} value={o.value}>
-                    {o.text}
-                  </option>
-                ))}
-              </select>
-            </div>
-
-            <div className="posts">
-              <div className="posts__message">
-                {!!this.state.posts.length && !this.state.loading && (
-                  <p>
-                    Browsing <span>[</span>"{this.state.term}"<span>]</span>
-                  </p>
-                )}
-              </div>
-
-              <div className="posts__grid">
-                {this.state.posts.map((post, i) => (
-                  <div className="post" key={post.id}>
-                    <img
-                      src={post.image}
-                      width="100"
-                      height="100"
-                      onClick={() => this.onPostClick(post.id)}
-                    />
-                    <div className="post__info">
-                      <p className="post__info__title" onClick={() => this.onPostClick(post.id)}>
-                        {post.title}
-                      </p>
-                      <div className="post__info__middle">
-                        <StarRatingComponent
-                          className="post__info__rating"
-                          name="rating"
-                          value={averageRating(post.reviews)}
-                          emptyStarColor="#eee"
-                        />
-                        <p className="post__info__author">{post.author}</p>
-                      </div>
-                      <div className="post__info__tags">{this.renderTags(post.tags)}</div>
-                    </div>
-                    <div className="post__details">
-                      <div className="post__details__row">
-                        <span>Language</span>
-                        <span>
-                          <b>[</b> {post.language} <b>]</b>
-                        </span>
-                      </div>
-                      <div className="post__details__row">
-                        <span>Difficulty</span>
-                        <span>
-                          <b>[</b> {post.difficulty} <b>]</b>
-                        </span>
-                      </div>
-                      <div className="post__details__row">
-                        <span>Price</span>
-                        <span>
-                          <b>[</b> {post.price} <b>]</b>
-                        </span>
-                      </div>
-                      <div className="post__details__row">
-                        <span>Content</span>
-                        <span>
-                          <b>[</b> {post.contentType} <b>]</b>
-                        </span>
-                      </div>
-                    </div>
-                  </div>
-                ))}
+                </div>
+                <div className="post__details__row">
+                  <span>Price</span>
+                  <span>
+                    <b>[</b> {formatPrice(post.price)} <b>]</b>
+                  </span>
+                </div>
+                <div className="post__details__row">
+                  <span>Content</span>
+                  <span>
+                    <b>[</b> {post.contentType} <b>]</b>
+                  </span>
+                </div>
               </div>
             </div>
-          </div>
-        )}
-      </ApolloConsumer>
+          ))}
+        </div>
+      </div>
     )
   }
 }
-
-export default withApollo(Posts)

--- a/frontend/components/Search.js
+++ b/frontend/components/Search.js
@@ -16,6 +16,11 @@ class Search extends React.Component {
     this.props.handleChange(e.target.value, this.props.client)
   }
 
+  handleClick = () => {
+    const { search } = this.state
+    this.props.handleClick(search, this.props.client)
+  }
+
   render() {
     return (
       <div className="search">
@@ -28,7 +33,7 @@ class Search extends React.Component {
           name="search"
           autoFocus
         />
-        <button className="search__button" type="submit">
+        <button className="search__button" onClick={this.handleClick}>
           🔍
         </button>
       </div>

--- a/frontend/components/Wrapper.js
+++ b/frontend/components/Wrapper.js
@@ -1,0 +1,282 @@
+import React from 'react'
+import { ApolloConsumer, withApollo } from 'react-apollo'
+import gql from 'graphql-tag'
+import Router from 'next/router'
+import debounce from 'lodash.debounce'
+import isEqual from 'lodash.isequal'
+import InnerHeader from './InnerHeader'
+import averageRating from '../lib/averageRating'
+import { PRICE, DIFFICULTY } from '../lib/filterConstants'
+import Filters from './Filters'
+
+// max number of posts returned per page
+const perPage = 30
+
+// the mongoloid
+const SEARCH_POSTS_QUERY = gql`
+  query SEARCH_POSTS_QUERY(
+    $term: String,
+    $difficulty: [Difficulty!],
+    $price: [PriceRange!],
+    $first: Int = ${perPage},
+    $skip: Int = 0,
+    $orderBy: PostOrderByInput = title_ASC
+    ) {
+    posts(
+      where: {
+        AND: [
+          { difficulty_in: $difficulty },
+          { price_in: $price }
+          {
+            OR: [
+            { title_contains: $term },
+            { description_contains: $term },
+            { author_contains: $term }
+            ]
+          }
+
+        ]
+
+      },
+      first: $first,
+      skip: $skip,
+      orderBy: $orderBy) {
+      id
+      title
+      description
+      language
+      contentType
+      tags
+      image
+      href
+      author
+      difficulty
+      price
+      createdAt
+      reviews {
+        id
+        text
+        rating
+        createdAt
+      }
+    }
+  }
+`
+
+// stops empty array going to query
+// makes default search for all filters
+function getQueryValue(arr, i) {
+  const params = [DIFFICULTY, PRICE]
+  if (!arr.length) {
+    return params[i]
+  }
+  return arr
+}
+
+class Wrapper extends React.Component {
+  state = {
+    pathname: null,
+    loading: false,
+    posts: [],
+    avgs: [],
+    term: '',
+    price: [],
+    difficulty: [],
+    orderBy: 0,
+  }
+
+  // adds listener for internal route change
+  componentDidMount() {
+    this.setPathname()
+    Router.events.on('routeChangeStart', this.handleRouteChange)
+    this.restoreSearchParams()
+  }
+
+  // clean up for event listeners
+  componentWillUnmount() {
+    Router.events.off('routeChangeStart', this.handleRouteChange)
+  }
+
+  // deep equal check on posts array
+  // when posts change find the average rating and rebuild post w/Object.assign
+  componentDidUpdate(prevProps, prevState) {
+    if (!isEqual(prevState.posts, this.state.posts)) {
+      const avgs = this.state.posts.map(post => averageRating(post.reviews))
+      const postsWithAvg = this.state.posts.map((post, i) =>
+        Object.assign({}, post, { averageRating: avgs[i] }))
+      this.setState({ posts: postsWithAvg })
+    }
+    if (Router.pathname !== this.state.pathname) {
+      this.setPathname()
+    }
+  }
+
+  setPathname = () => this.setState({ pathname: Router.pathname })
+
+  // debounce to .5s against user key input
+  handleChange = debounce(async (term, client) => {
+    if (this.state.pathname !== '/posts') {
+      return this.setState({ term })
+    }
+    if (!term) return this.setState({ posts: [], term })
+    this.setState({ loading: true, term })
+    // if no difficulty is selected act as if they all are
+    const difficulty = this.state.difficulty.length ? this.state.difficulty : DIFFICULTY
+    // query the prisma client directly
+    const res = await client.query({
+      query: SEARCH_POSTS_QUERY,
+      variables: { term, difficulty },
+    })
+    return this.setState({ loading: false, posts: res.data.posts })
+  }, 500)
+
+  handleClick = async (term, client) => {
+    if (this.state.pathname === '/posts') return
+    Router.push('/posts')
+  }
+
+  // refetch query when user changes price array
+  handlePrice = async (p, client) => {
+    this.setState({ loading: true })
+    const { difficulty } = this.state
+    let { price } = this.state
+
+    if (price.includes(p)) {
+      price = price.filter(el => el !== p)
+    } else {
+      price.push(p)
+    }
+
+    const queryPrice = getQueryValue(price, 1)
+    const queryDifficulty = getQueryValue(difficulty, 0)
+
+    const res = await client.query({
+      query: SEARCH_POSTS_QUERY,
+      variables: { term: this.state.term, price: queryPrice, difficulty: queryDifficulty },
+    })
+
+    this.setState({ loading: false, price, posts: res.data.posts })
+  }
+
+  // refetch every time user changes difficulty array
+  handleDifficulty = async (d, client) => {
+    this.setState({ loading: true })
+    const { price } = this.state
+    let { difficulty } = this.state
+    // filter or replace based on pre existance
+    if (difficulty.includes(d)) {
+      difficulty = difficulty.filter(el => el !== d)
+    } else {
+      difficulty.push(d)
+    }
+    // check to see if none are checked
+    const queryPrice = getQueryValue(price, 1)
+    const queryDifficulty = getQueryValue(difficulty, 0)
+    // query prisma with both search term and difficulty
+    const res = await client.query({
+      query: SEARCH_POSTS_QUERY,
+      variables: { term: this.state.term, difficulty: queryDifficulty, price: queryPrice },
+    })
+    this.setState({ loading: false, difficulty, posts: res.data.posts })
+  }
+
+  // no query to prisma here, just sort what we have
+  handleOrderBy = e => {
+    const orderBy = Number(e.target.value)
+    const { posts } = this.state
+    let sortedPosts
+    // simple alphabetical sort this is default for now
+    if (orderBy === 0) {
+      sortedPosts = posts.sort((a, b) => {
+        const x = a.title.toLowerCase()
+        const y = b.title.toLowerCase()
+        if (x < y) return -1
+        if (x > y) return 1
+        return 0
+      })
+      // find the averages and sort from highest to lowest average
+    } else if (orderBy === 1) {
+      sortedPosts = posts.sort((a, b) => averageRating(b.reviews) - averageRating(a.reviews))
+      // count reviews and sort from most to least
+    } else {
+      sortedPosts = posts.sort((a, b) => b.reviews.length - a.reviews.length)
+    }
+    this.setState({ posts: sortedPosts, orderBy })
+  }
+
+  // stores search criteria in session storage
+  handleRouteChange = () => {
+    const { term, difficulty, price, orderBy } = this.state
+    const params = { term, difficulty, price, orderBy }
+    sessionStorage.setItem('parameters', JSON.stringify(params)) // eslint-disable-line
+  }
+
+  // restores posts using withApollo HOC and session storage
+  restoreSearchParams = async () => {
+    const params = JSON.parse(sessionStorage.getItem('parameters')) // eslint-disable-line
+    if (!params) return
+
+    const { term, difficulty, price, orderBy } = params
+    const queryPrice = getQueryValue(price, 1)
+    const queryDifficulty = getQueryValue(difficulty, 0)
+
+    const res = await this.props.client.query({
+      query: SEARCH_POSTS_QUERY,
+      variables: {
+        term,
+        difficulty: queryDifficulty,
+        price: queryPrice,
+      },
+    })
+
+    const fakeEvent = { target: { value: orderBy } }
+    this.handleOrderBy(fakeEvent)
+
+    this.setState({
+      term,
+      difficulty,
+      price,
+      posts: res.data.posts,
+      orderBy,
+    })
+  }
+
+  render() {
+    const {
+      state: { pathname, loading, posts, term, price, difficulty, orderBy },
+    } = this
+    return (
+      <ApolloConsumer>
+        {client => (
+          <div className="posts__component">
+            <InnerHeader
+              client={client}
+              term={term}
+              handleChange={this.handleChange}
+              handleClick={this.handleClick}
+            />
+            {pathname === '/posts' && (
+              <Filters
+                client={client}
+                price={price}
+                difficulty={difficulty}
+                orderBy={orderBy}
+                handlePrice={this.handlePrice}
+                handleDifficulty={this.handleDifficulty}
+                handleOrderBy={this.handleOrderBy}
+              />
+            )}
+            {React.Children.map(this.props.children, child =>
+              React.cloneElement(child, {
+                loading,
+                posts,
+                term,
+              }))}
+          </div>
+        )}
+      </ApolloConsumer>
+    )
+  }
+}
+
+export default withApollo(Wrapper)

--- a/frontend/lib/filterConstants.js
+++ b/frontend/lib/filterConstants.js
@@ -1,0 +1,9 @@
+export const PRICE = ['FREE', 'LOW', 'MID', 'HIGH']
+
+export const ORDER_BY = [
+  { text: 'Alphabetical', value: 0 },
+  { text: 'Highest Rating', value: 1 },
+  { text: 'Most Reviewed', value: 2 },
+]
+
+export const DIFFICULTY = ['EASY', 'MID', 'HARD', 'EXPERT']

--- a/frontend/lib/formatPrice.js
+++ b/frontend/lib/formatPrice.js
@@ -1,0 +1,12 @@
+const PRICE = ['FREE', 'LOW', 'MID', 'HIGH']
+
+const formatPrice = p => {
+  const i = PRICE.indexOf(p)
+  if (i === 0) return 'FREE'
+  if (i === 1) return '$'
+  if (i === 2) return '$$'
+  if (i === 3) return '$$$'
+  return null
+}
+
+export default formatPrice

--- a/frontend/pages/posts.js
+++ b/frontend/pages/posts.js
@@ -1,7 +1,8 @@
+import Wrapper from '../components/Wrapper'
 import Posts from '../components/Posts'
 
 export default props => (
-  <div>
+  <Wrapper>
     <Posts />
-  </div>
+  </Wrapper>
 )

--- a/frontend/pages/test-wrap.js
+++ b/frontend/pages/test-wrap.js
@@ -1,0 +1,20 @@
+import Wrapper from '../components/Wrapper'
+
+export default props => (
+  <Wrapper>
+    <div>
+      <img src="https://media.giphy.com/media/PV9t4AJL5UweI/giphy.gif" />
+      <img src="https://media.giphy.com/media/PV9t4AJL5UweI/giphy.gif" />
+      <img src="https://media.giphy.com/media/PV9t4AJL5UweI/giphy.gif" />
+      <img src="https://media.giphy.com/media/PV9t4AJL5UweI/giphy.gif" />
+      <img src="https://media.giphy.com/media/PV9t4AJL5UweI/giphy.gif" />
+      <img src="https://media.giphy.com/media/PV9t4AJL5UweI/giphy.gif" />
+      <img src="https://media.giphy.com/media/PV9t4AJL5UweI/giphy.gif" />
+      <img src="https://media.giphy.com/media/PV9t4AJL5UweI/giphy.gif" />
+      <img src="https://media.giphy.com/media/PV9t4AJL5UweI/giphy.gif" />
+      <img src="https://media.giphy.com/media/PV9t4AJL5UweI/giphy.gif" />
+      <img src="https://media.giphy.com/media/PV9t4AJL5UweI/giphy.gif" />
+      <img src="https://media.giphy.com/media/PV9t4AJL5UweI/giphy.gif" />
+    </div>
+  </Wrapper>
+)

--- a/frontend/styles/components/search.scss
+++ b/frontend/styles/components/search.scss
@@ -9,8 +9,7 @@
 }
 
 .search__bar {
-  width: 85%;
-  margin-right: 10px;
+  width: 75%;
 }
 
 .search__button {


### PR DESCRIPTION
# Description

Refactors Search into Wrapper component

See `/test-wrap` page for example usage

Allows header with search to be on any page. When on `/posts` render additional filters and update search on keypress. When not on `/posts` search is typed in but not executed until search button is pressed. Then user is routed to `/posts`.

Adds `formatPrice` to `lib`. Use to turn price such as 'HIGH' or 'MID' to '$$$' and '$$'. Easy to use this helper function than to refactor seed func, resolvers and google sheet.

Usage: `formatPrice(post.price)`

Code is still a little sloppy...will clean up in next commit

## Type of change

- [x] New feature (non-breaking change which adds functionality)

## Change status
- [x] Incomplete/work-in-progress, PR is for discussion/feedback

# Checklist:

- [ ] My code follows the style guidelines of this project
- [x] I have performed a self-review of my own code
- [ ] My code has been reviewed by at least one peer
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings
- [ ] I have added tests that prove my fix is effective or that my feature works
- [ ] New and existing unit tests pass locally with my changes
- [ ] There are no merge conflicts
